### PR TITLE
RM67893 Allow keypair and credentials as vars

### DIFF
--- a/deployments/aws/cas-mgr-single-connector/vars.tf
+++ b/deployments/aws/cas-mgr-single-connector/vars.tf
@@ -20,6 +20,16 @@ variable "aws_region" {
   default     = "us-west-1"
 }
 
+variable "keypair_name" {
+  description = "AWS Keypair used to SSH onto EC2 instances"
+  default     = ""
+}
+
+variable "cas_mgr_aws_credentials_string" {
+  description = "String version of the aws credentials file"
+  default     = ""
+}
+
 # "usw2-az4" failed to provision t2.xlarge EC2 instances in April 2020
 # "use1-az3" failed to provision g4dn.xlarge Windows EC2 instances in April 2020
 variable "az_id_exclude_list" {

--- a/modules/aws/cas-mgr/cas-mgr-provisioning.sh.tmpl
+++ b/modules/aws/cas-mgr/cas-mgr-provisioning.sh.tmpl
@@ -114,10 +114,11 @@ get_credentials() {
         log "--> Decrypting PCoIP registration code..."
         PCOIP_REGISTRATION_CODE=$(aws kms decrypt --region ${aws_region} --ciphertext-blob fileb://<(echo "${pcoip_registration_code}" | base64 -d) --output text --query Plaintext | base64 -d)
 
+        # NOTE: credentials file is no longer binary, so changing format passed as ciphertext-blob from fileb to file
         if [ "${cas_mgr_aws_credentials_file}" ]
         then
             log "--> Decrypting AWS Service Account credentials file..."
-            aws kms decrypt --region ${aws_region} --ciphertext-blob "fileb://$INSTALL_DIR/${cas_mgr_aws_credentials_file}" --output text --query Plaintext | base64 -d > "$INSTALL_DIR/${cas_mgr_aws_credentials_file}.decrypted"
+            aws kms decrypt --region ${aws_region} --ciphertext-blob "file://$INSTALL_DIR/${cas_mgr_aws_credentials_file}" --output text --query Plaintext | base64 -d > "$INSTALL_DIR/${cas_mgr_aws_credentials_file}.decrypted"
             mv "${cas_mgr_aws_credentials_file}.decrypted" "$INSTALL_DIR/${cas_mgr_aws_credentials_file}"
         fi
     fi


### PR DESCRIPTION
The existing code creates a keypair using a public key file read from
disk, and also uploads aws credentials to S3 by reading a file from
disk.  While this can work from the command line, our standard model
of operation is to upload inventories to Terraform Cloud and apply
the deployment from there.  The Terraform Cloud deployments will fail
if we try to use the file-based approach.

To work around this, we introduce changes to
1. Allow the keypair name to be passed in; if this is done then the
code skips creating a keypair since it won't be needed
2. Allow the credentials file _contents_ to be passed in as an
encrypted string.  When this is done the code creates a _local_ file
with those contents, and then the code proceeds as normal to upload
the contents of the now _local_ file to s3.

References RM-67893