### PR TITLE
Eliminating unused variables

### DIFF
--- a/deployments/aws/cas-mgr-single-connector/main.tf
+++ b/deployments/aws/cas-mgr-single-connector/main.tf
@@ -12,6 +12,7 @@ locals {
   cas_mgr_deployment_sa_file = "cas-mgr-deployment-sa-key.json"
   # ES - Use a predefined keypair if one is passed in, otherwise create one
   admin_ssh_key_name = var.keypair_name != "" ? var.keypair_name : "${local.prefix}${var.admin_ssh_key_name}"
+  aws_credentials_string = var.aws_credentials_string
   cas_mgr_aws_credentials_file = "cas-mgr-aws-credentials.ini"
   cas_mgr_aws_credentials_string = var.cas_mgr_aws_credentials_string
   

--- a/deployments/aws/cas-mgr-single-connector/vars.tf
+++ b/deployments/aws/cas-mgr-single-connector/vars.tf
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/* Eliminating the requirement for this variable, as it was only used in providers.tf which
+ * is not part of the EditShare version of the repo
 variable "aws_credentials_file" {
     description = "Location of AWS credentials file"
     type        = string
@@ -14,6 +16,7 @@ variable "aws_credentials_file" {
       error_message = "The aws_credentials_file specified does not exist. Please check the file path."
     }
 }
+*/
 
 variable "aws_region" {
   description = "AWS region"
@@ -26,6 +29,11 @@ variable "keypair_name" {
 }
 
 variable "cas_mgr_aws_credentials_string" {
+  description = "String version of the aws credentials file"
+  default     = ""
+}
+
+variable "aws_credentials_string" {
   description = "String version of the aws credentials file"
   default     = ""
 }
@@ -205,10 +213,13 @@ variable "cas_mgr_aws_credentials_file" {
     description = "Location of AWS credentials file for CAS Manager"
     type        = string
 
-    validation {
-      condition = fileexists(var.cas_mgr_aws_credentials_file)
-      error_message = "The cas_mgr_aws_credentials_file specified does not exist. Please check the file path."
-    }
+    # Removing validation as the file is not required for the editshare version of code
+    # Supplying a default so we don't have to supply a variable
+    default     = ""
+    # validation {
+    #   condition = fileexists(var.cas_mgr_aws_credentials_file)
+    #   error_message = "The cas_mgr_aws_credentials_file specified does not exist. Please check the file path."
+    # }
 }
 
 variable "cas_connector_subnet_name" {


### PR DESCRIPTION
References to the credentials files are no longer required based on
the editshare version of the cloud_deployment_scripts repo, so
eliminating them as required variables.

References RM-