### PR TITLE
RM-69779 Support DC and CAS Mgr in Private Subnet

### DIFF
--- a/modules/aws/cas-connector/cas-connector-provisioning.sh.tmpl
+++ b/modules/aws/cas-connector/cas-connector-provisioning.sh.tmpl
@@ -5,12 +5,12 @@
 
 #!/bin/bash
 
+PROVISIONING_DIR="/root"
 CAS_CONNECTOR_BIN_PATH="/usr/local/bin/cas-connector"
 CAS_CONNECTOR_REPO_SETUP_SCRIPT_URL="https://dl.teradici.com/${teradici_download_token}/cas-manager-beta/cfg/setup/bash.rpm.sh"
 CAS_CONNECTOR_INSTALL_LOG="/var/log/teradici/cas-connector-install.log"
 CONNECTOR_TOKEN_FILE=$PROVISIONING_DIR/connector_token
 LOG_FILE="/var/log/teradici/provisioning.log"
-PROVISIONING_DIR="/root"
 
 log() {
     local message="$1"
@@ -123,6 +123,7 @@ get_connector_token() {
     dos2unix $PROVISIONING_DIR/${cas_mgr_script}
     dos2unix $PROVISIONING_DIR/${cas_mgr_deployment_sa_file}
 
+    # EditShare
     # Set CONNECTOR_TOKEN variable using the script's output
     if [ "${cas_mgr_insecure}" ]
     then
@@ -133,7 +134,7 @@ get_connector_token() {
     set +x
     CONNECTOR_TOKEN=`cat $CONNECTOR_TOKEN_FILE`
     set -x
-    rm $CONNECTOR_TOKEN_FILE
+    #rm $CONNECTOR_TOKEN_FILE
 
     # Check and exit provisioning script if retrieving connector token failed
     if [ $? -ne 0 ]; then
@@ -281,7 +282,7 @@ configure_cas_connector() {
     log "  --retrieve-agent-state true"
     log "  --show-agent-state true"
     log "  --sync-interval 5"
-    log "  --casm-url ${cas_mgr_url}"
+    log "  --manager-url ${cas_mgr_url}"
     log "  ${cas_connector_extra_install_flags}"
 
     # Set pipefail option to return status of the connector install command
@@ -309,8 +310,8 @@ configure_cas_connector() {
 
     if [ "${cas_mgr_insecure}" ]
     then
-        log "  --casm-insecure"
-        args=$args"--casm-insecure "
+        log "  --manager-insecure"
+        args=$args"--manager-insecure "
     fi
 
     if [ "${lls_ip}" ]
@@ -319,6 +320,27 @@ configure_cas_connector() {
         args=$args"--local-license-server-url http://${lls_ip}:7070/request "
     fi
 
+    # EditShare save the connect command to a local file just in case
+    cat << EOF > connect.sh
+export CONNECTOR_TOKEN=`cat connector_token` 
+$CAS_CONNECTOR_BIN_PATH configure \
+--debug \
+--token $CONNECTOR_TOKEN \
+--accept-policies \
+--computers-dn ${computers_dn} \
+--users-dn ${users_dn} \
+--sa-user ${ad_service_account_username} \
+--sa-password $AD_SERVICE_ACCOUNT_PASSWORD \
+--domain ${domain_name} \
+--ldaps-ca-cert $PROVISIONING_DIR/${ldaps_cert_filename} \
+--retrieve-agent-state true \
+--show-agent-state true \
+--sync-interval 5 \
+--manager-url ${cas_mgr_url} \
+--manager-insecure
+EOF
+
+    # EditShare use args manager-url and manager-insecure
     set +x
     retry 10 `# 10 retries` \
         10 `# 10s interval` \
@@ -335,7 +357,7 @@ configure_cas_connector() {
         --retrieve-agent-state true \
         --show-agent-state true \
         --sync-interval 5 \
-        --casm-url ${cas_mgr_url} \
+        --manager-url ${cas_mgr_url} \
         ${cas_connector_extra_install_flags} \
         $args \
         2>&1 | tee -a $CAS_CONNECTOR_INSTALL_LOG" \

--- a/modules/aws/cas-connector/main.tf
+++ b/modules/aws/cas-connector/main.tf
@@ -252,11 +252,11 @@ resource "aws_instance" "cas-connector" {
     volume_size = var.disk_size_gb
   }
 
-  associate_public_ip_address = true
+  ###associate_public_ip_address = true
 
   vpc_security_group_ids = var.security_group_ids
 
-  key_name = var.admin_ssh_key_name
+  key_name = var.keypair_name ### var.admin_ssh_key_name
 
   iam_instance_profile = aws_iam_instance_profile.cas-connector-instance-profile[0].name
 

--- a/modules/aws/cas-connector/main.tf
+++ b/modules/aws/cas-connector/main.tf
@@ -252,11 +252,9 @@ resource "aws_instance" "cas-connector" {
     volume_size = var.disk_size_gb
   }
 
-  ###associate_public_ip_address = true
-
   vpc_security_group_ids = var.security_group_ids
 
-  key_name = var.keypair_name ### var.admin_ssh_key_name
+  key_name = var.keypair_name
 
   iam_instance_profile = aws_iam_instance_profile.cas-connector-instance-profile[0].name
 

--- a/modules/aws/cas-connector/vars.tf
+++ b/modules/aws/cas-connector/vars.tf
@@ -190,3 +190,8 @@ variable "aws_ssm_enable" {
   description = "Enable AWS Session Manager integration for easier SSH/RDP admin access to EC2 instances"
   default     = true
 }
+
+variable "keypair_name" {
+  description = "key name to use for accessing the AWS Instances"
+}
+

--- a/modules/aws/cas-mgr/main.tf
+++ b/modules/aws/cas-mgr/main.tf
@@ -195,7 +195,6 @@ resource "aws_instance" "cas-mgr" {
 
   ami           = data.aws_ami.ami.id
   instance_type = var.instance_type
-  ### FIXME
   key_name      = var.keypair_name
 
 
@@ -204,11 +203,7 @@ resource "aws_instance" "cas-mgr" {
     volume_size = var.disk_size_gb
   }
 
-  ###associate_public_ip_address = var.enable_public_ip
-
   vpc_security_group_ids = var.security_group_ids
-
-  ###key_name = var.admin_ssh_key_name
 
   iam_instance_profile = aws_iam_instance_profile.cas-mgr-instance-profile.name
 

--- a/modules/aws/cas-mgr/main.tf
+++ b/modules/aws/cas-mgr/main.tf
@@ -195,17 +195,20 @@ resource "aws_instance" "cas-mgr" {
 
   ami           = data.aws_ami.ami.id
   instance_type = var.instance_type
+  ### FIXME
+  key_name      = var.keypair_name
+
 
   root_block_device {
     volume_type = "gp2"
     volume_size = var.disk_size_gb
   }
 
-  associate_public_ip_address = var.enable_public_ip
+  ###associate_public_ip_address = var.enable_public_ip
 
   vpc_security_group_ids = var.security_group_ids
 
-  key_name = var.admin_ssh_key_name
+  ###key_name = var.admin_ssh_key_name
 
   iam_instance_profile = aws_iam_instance_profile.cas-mgr-instance-profile.name
 

--- a/modules/aws/cas-mgr/vars.tf
+++ b/modules/aws/cas-mgr/vars.tf
@@ -112,3 +112,8 @@ variable "aws_ssm_enable" {
   description = "Enable AWS Session Manager integration for easier SSH/RDP admin access to EC2 instances"
   default     = true
 }
+
+variable "keypair_name" {
+  description = "key name to use for accessing the AWS Instances"
+}
+


### PR DESCRIPTION
In order to comply with best security practices we need to deploy the
CAS Manager and Domain Controller in private subnets.  The dc module
cannot easily be modified to accomplish this, and has been absorbed into
the third_party_modules/teradici/editshare_deployments folder inside
terraform-deploy. The manager and connector can easily be modified by
eliminating the hardcoding of assigning a public IP to the instance,
and allowing the keypair used by the main terraform root module to be
applied to all of the teradici components.
    
References RM-69779
