### PR TITLE
RM-70498 Install ssm-agent on CAC and CAM

### DIFF
--- a/modules/aws/cas-connector/user-data.sh.tmpl
+++ b/modules/aws/cas-connector/user-data.sh.tmpl
@@ -58,6 +58,10 @@ then
 
         # Make aws available for root later
         ln -s /usr/local/bin/aws /usr/bin/aws
+
+        # Install ssm-agent
+        log "Installing ssm-agent"
+        dnf install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
     fi
 
     # wait until we have IAM credentials

--- a/modules/aws/cas-mgr/user-data.sh.tmpl
+++ b/modules/aws/cas-mgr/user-data.sh.tmpl
@@ -58,6 +58,10 @@ then
 
         # Make aws available for root later
         ln -s /usr/local/bin/aws /usr/bin/aws
+
+        # Install ssm-agent
+        log "Installing ssm-agent"
+        dnf install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
     fi
 
     # wait until we have IAM credentials


### PR DESCRIPTION
Simply installing ssm-agent on CAC and CAM to allow a Connect from the
AWS Console which can simplify troubleshooting.

RM-70498