### PR TITLE
RM-70498 Install ssm-agent on CAC and CAM

### DIFF
--- a/modules/aws/cas-connector/output.tf
+++ b/modules/aws/cas-connector/output.tf
@@ -16,3 +16,8 @@ output "public-ip" {
 output "instance-id" {
   value = aws_instance.cas-connector[*].id
 }
+
+output "cas-connector-role-id" {
+  value = aws_iam_role.cas-connector-role[0].id
+}
+

--- a/modules/aws/cas-mgr/output.tf
+++ b/modules/aws/cas-mgr/output.tf
@@ -16,3 +16,8 @@ output "public-ip" {
 output "instance-id" {
   value = aws_instance.cas-mgr.id
 }
+
+output "cas-mgr-role-id" {
+  value = aws_iam_role.cas-mgr-role.id
+}
+


### PR DESCRIPTION
Simply installing ssm-agent on CAC and CAM to allow a Connect from the 
AWS Console which can simplify troubleshooting.  Adding output of 
role id from each so we can attach the ssm-agent policy that allows access

References RM-70498