### PR TITLE
RM-71371 Adding user_data to lifecycle policy

### DIFF
--- a/modules/aws/cas-connector/main.tf
+++ b/modules/aws/cas-connector/main.tf
@@ -262,6 +262,10 @@ resource "aws_instance" "cas-connector" {
 
   lifecycle {
     ignore_changes = [
+      # Ignore changes to user_data, since we only use it when
+      # the node initializes and we do not want subsequent
+      # enhancements to user_data to cause the node to be replaced
+      user_data,
       # Since the DC runs on a standard AWS Windows Server, it's possible that
       # AWS will eventually age out the AMI used to initially deploy the DC,
       # so we ignore AMI changes here

--- a/modules/aws/cas-mgr/main.tf
+++ b/modules/aws/cas-mgr/main.tf
@@ -211,6 +211,10 @@ resource "aws_instance" "cas-mgr" {
 
   lifecycle {
     ignore_changes = [
+      # Ignore changes to user_data, since we only use it when
+      # the node initializes and we do not want subsequent
+      # enhancements to user_data to cause the node to be replaced
+      user_data,
       # Since the DC runs on a standard AWS Windows Server, it's possible that
       # AWS will eventually age out the AMI used to initially deploy the DC,
       # so we ignore AMI changes here


### PR DESCRIPTION
We need to gnore changes to user_data, since we only use it when the node initializes and we do not want subsequent enhancements to user_data to cause the node to be replaced

References RM-71371