### PR TITLE
RM-71386 Adding Name tag to CAS root devices

### DIFF
--- a/modules/aws/cas-connector/main.tf
+++ b/modules/aws/cas-connector/main.tf
@@ -250,6 +250,13 @@ resource "aws_instance" "cas-connector" {
   root_block_device {
     volume_type = "gp2"
     volume_size = var.disk_size_gb
+    tags = merge(
+      {
+        Name = "vol-${var.prefix}-sda1-connector"
+      },
+      {} # var.common_tags
+    )
+
   }
 
   vpc_security_group_ids = var.security_group_ids

--- a/modules/aws/cas-mgr/main.tf
+++ b/modules/aws/cas-mgr/main.tf
@@ -201,6 +201,12 @@ resource "aws_instance" "cas-mgr" {
   root_block_device {
     volume_type = "gp2"
     volume_size = var.disk_size_gb
+    tags = merge(
+      {
+        Name = "vol-${var.prefix}-sda1-manager"
+      },
+      {} # var.common_tags
+    )
   }
 
   vpc_security_group_ids = var.security_group_ids


### PR DESCRIPTION
Adding a Name tag to the root_block_device for the Connector and Manager to support tracking resources.  To minimize the changes to the original code from teradici, only setting the Name tag and not merging with the common_tags as is done elsewhere, which means we can avoid a lot of changes to pass that variable down into those modules.

References RM-71386