### PR TITLE
RM-71386 Adding Name tag to CAS root devices

### DIFF
--- a/modules/aws/cas-connector/main.tf
+++ b/modules/aws/cas-connector/main.tf
@@ -254,7 +254,7 @@ resource "aws_instance" "cas-connector" {
       {
         Name = "vol-${var.prefix}-sda1-connector"
       },
-      {} # var.common_tags
+      {Environment = "${var.prefix}"} # var.common_tags
     )
 
   }

--- a/modules/aws/cas-mgr/main.tf
+++ b/modules/aws/cas-mgr/main.tf
@@ -205,7 +205,7 @@ resource "aws_instance" "cas-mgr" {
       {
         Name = "vol-${var.prefix}-sda1-manager"
       },
-      {} # var.common_tags
+      {Environment = "${var.prefix}"} # var.common_tags
     )
   }
 


### PR DESCRIPTION
Adding a Name tag to the root_block_device for the Connector and Manager to support tracking resources.  To minimize the changes to the original code from teradici, only setting the Name tag and not merging with the common_tags as is done elsewhere, which means we can avoid a lot of changes to pass that variable down into those modules.

References RM-71386